### PR TITLE
fix: request wagmi provider missing configs

### DIFF
--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sky-mavis/tanto-wagmi",
   "type": "module",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Tanto Wagmi",
   "main": "dist/cjs/index.js",
   "types": "dist/types/index.d.ts",

--- a/packages/wagmi/src/connectors/waypoint.ts
+++ b/packages/wagmi/src/connectors/waypoint.ts
@@ -12,7 +12,7 @@ import { ConnectParams } from '../types';
 
 export function waypoint(params: IWaypointProviderConfigs) {
   const provider = requestWaypointProvider(params);
-  const connector = new WaypointConnector({ provider });
+  const connector = new WaypointConnector({ provider, providerConfigs: params });
 
   const _connect = async (params?: ConnectParams) => {
     const { chainId } = await connector.connect(params?.chainId);


### PR DESCRIPTION

in case chainId && currentChainId !== chainId, `requestProvider` will be call with empty configs
``` title: src/connectors/waypoint/WaypointConnector.ts
  async connect(chainId?: number) {
    const currentChainId = await this.getChainId();
    if (chainId && currentChainId !== chainId) {
      this.provider = await this.requestProvider({ chainId });
    }
  //...
  }

  async requestProvider(configs?: IWaypointProviderConfigs) {
    return requestWaypointProvider({ ...this.providerConfigs, ...configs });
  }
```